### PR TITLE
adding updates for WW3

### DIFF
--- a/compsets/all.input
+++ b/compsets/all.input
@@ -7,7 +7,7 @@ run fv3_ccpp_control            @ fv3, standard, ccpptrans, plat==hera.intel
 run fv3_restart                 @ fv3, standard, baseline
 run fv3_read_inc                @ fv3, standard, baseline
 run fv3_gfdlmp                  @ fv3, standard, baseline
-run fv3_gfdlmprad               @ fv3, standard, baseline, ww3, plat==wcoss_dell_p3,plat==wcoss.cray
+run fv3_gfdlmprad               @ fv3, standard, baseline, ww3, plat==hera.intel,plat==wcoss_dell_p3,plat==wcoss.cray
 run fv3_gfdlmprad_gwd           @ fv3, standard, baseline
 run fv3_gfdlmprad_noahmp        @ fv3, standard, baseline
 run fv3_thompson                @ fv3, standard, baseline
@@ -22,7 +22,7 @@ run fv3_wrtGauss_netcdf_esmf    @ fv3, standard, baseline
 run fv3_wrtGauss_netcdf         @ fv3, standard, baseline
 run fv3_wrtGauss_nemsio         @ fv3, standard, baseline
 
-run fv3_wrtGauss_nemsio_c768    @ fv3,           baseline, ww3, plat==wcoss.cray
+run fv3_wrtGauss_nemsio_c768    @ fv3,           baseline, ww3, plat==hera.intel, plat==wcoss.cray, plat==wcoss_dell_p3
 run fv3_wrtGauss_nemsio_c192    @ fv3, standard, baseline
 run fv3_stochy                  @ fv3, standard, baseline
 run fv3_iau                     @ fv3, standard, baseline

--- a/compsets/fv3.input
+++ b/compsets/fv3.input
@@ -1210,9 +1210,11 @@ test fv3_gfdlmprad: fv3_ww3.exe {
         'RESTART/sfc_data.tile4.nc'             .bitcmp. "@[CNTL]/RESTART/"
         'RESTART/sfc_data.tile5.nc'             .bitcmp. "@[CNTL]/RESTART/"
         'RESTART/sfc_data.tile6.nc'             .bitcmp. "@[CNTL]/RESTART/"
+        'out_grd.glo_30m'                       .bitcmp. "@[CNTL]"
+        'weightmatrix_ATM-TO-WAV_inst_merid_wind_height10m.nc' .bitcmp. "@[CNTL]"
+        'weightmatrix_ATM-TO-WAV_inst_zonal_wind_height10m.nc' .bitcmp. "@[CNTL]"
         "@[build%target]" .md5cmp. "@[fv3_ww3.exe%md5sum]"
     }
-
 
     spawn execute {
         {"@[build%target]", ranks="@[TASKS]" }
@@ -1634,7 +1636,6 @@ test fv3_wrtGauss_netcdf_esmf: fv3.exe {
     }
 }
 
-
 ########################################################################
 
 test fv3_wrtGauss_nemsio_c192: fv3.exe {
@@ -1763,7 +1764,6 @@ test fv3_wrtGauss_nemsio_c768: fv3_ww3.exe {
     CNTL_NAME="fv3_wrtGauss_nemsio_c768"
 
     TASKS='1752'
-    TPN='12'
     PPN="@[plat%C768_PPN]"
     INPES='16'
     JNPES='16'
@@ -1878,7 +1878,9 @@ test fv3_wrtGauss_nemsio_c768: fv3_ww3.exe {
         'RESTART/sfc_data.tile4.nc'             .bitcmp. "@[CNTL]/RESTART/"
         'RESTART/sfc_data.tile5.nc'             .bitcmp. "@[CNTL]/RESTART/"
         'RESTART/sfc_data.tile6.nc'             .bitcmp. "@[CNTL]/RESTART/"
-
+        'out_grd.glo_30m'                       .bitcmp. "@[CNTL]"
+        'weightmatrix_ATM-TO-WAV_inst_merid_wind_height10m.nc' .bitcmp. "@[CNTL]"
+        'weightmatrix_ATM-TO-WAV_inst_zonal_wind_height10m.nc' .bitcmp. "@[CNTL]"
       # Executable validation.  This makes an MD5 sum of the fv3.exe
       # for comparison against the MD5 sum made in the build job.
       # This is to ensure the executable did not change during the

--- a/compsets/hera.input
+++ b/compsets/hera.input
@@ -16,8 +16,12 @@ platform hera.intel {
 
     cores_per_node=40 # Number of cores per node on compute nodes
     cpus_per_core=2
+    C768_PPN=30
 
-    # The *nems locations are in NEMS checkout areas.
+ # hera testing: using longer run time
+    DEFAULT_TEST_WALLTIME=3000
+
+ #  The *nems locations are in NEMS checkout areas.
     HOMEnems=PWD_UP5
 
     # The *rt locations are auto-generated areas.

--- a/parm/gfdlmp.nml.IN
+++ b/parm/gfdlmp.nml.IN
@@ -171,6 +171,8 @@
        debug          = .false.
        h2o_phys       = @[H2O_PHYS]
        nstf_name      = @[NSTF_NAME]
+       cplflx         = @[CPLFLX]
+       cplwav         = @[CPLWAV]
        xkzminv        = 0.3
        xkzm_m         = 1.0
        xkzm_h         = 1.0

--- a/parm/nems.configure
+++ b/parm/nems.configure
@@ -1,0 +1,5 @@
+ EARTH_component_list: ATM
+ ATM_model:            fv3
+ runSeq::
+   ATM
+ ::

--- a/tests/fv3_conf/fv3_run.IN
+++ b/tests/fv3_conf/fv3_run.IN
@@ -31,3 +31,8 @@ fi
 cp    @[RTPWD]/${inputdir}/*grb .
 cp    @[RTPWD]/${inputdir}/*_table .
 cp    @[RTPWD]/${inputdir}/*configure .
+
+if [ $CPLWAV = .T. ]; then
+cp    @[RTPWD]/WW3_input_data/mod_def.* .
+cp    @[RTPWD]/WW3_input_data/@[SYEAR]@[SMONTH]@[SDAY]/ww3_multi.inp .
+fi

--- a/tests/fv3_conf/fv3_slurm.IN_hera
+++ b/tests/fv3_conf/fv3_slurm.IN_hera
@@ -3,7 +3,9 @@
 #SBATCH -o out
 #SBATCH --account=@[ACCNR]
 #SBATCH --qos=@[QUEUE]
-#SBATCH --ntasks=@[TASKS]
+### #SBATCH --ntasks=@[TASKS]
+#SBATCH --nodes=@[NODES]
+#SBATCH --ntasks-per-node=@[TPN]
 #SBATCH --time=@[WLCLK]
 #SBATCH --job-name="@[JBNME]"
 #SBATCH --exclusive
@@ -30,7 +32,7 @@ export PSM_SHAREDCONTEXTS=1
 # Avoid job errors because of filesystem synchronization delays
 sync && sleep 1
 
-srun --label ./fv3.exe
+srun --label -n @[TASKS] ./fv3.exe
 
 echo "Model ended:    " `date`
 

--- a/tests/fv3_conf/gfdlmp_run.IN
+++ b/tests/fv3_conf/gfdlmp_run.IN
@@ -16,3 +16,8 @@ cp    @[RTPWD]/FV3_input_data/*_table .
 cp    @[RTPWD]/FV3_input_data/diag_table_gfdlmp diag_table
 cp    @[RTPWD]/FV3_input_data/field_table_gfdlmp field_table
 cp    @[RTPWD]/FV3_input_data/*configure .
+
+if [ $CPLWAV = .T. ]; then
+cp    @[RTPWD]/WW3_input_data/mod_def.* .
+cp    @[RTPWD]/WW3_input_data/@[SYEAR]@[SMONTH]@[SDAY]/ww3_multi.inp .
+fi

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -16,7 +16,6 @@ RUN     | fv3_2threads                                                          
 RUN     | fv3_restart                                                                                                                    | standard    |                | fv3         |
 RUN     | fv3_read_inc                                                                                                                   | standard    |                | fv3         |
 RUN     | fv3_gfdlmp                                                                                                                     | standard    |                | fv3         |
-RUN     | fv3_gfdlmprad                                                                                                                  | standard    |                | fv3         |
 RUN     | fv3_gfdlmprad_gwd                                                                                                              | standard    |                | fv3         |
 RUN     | fv3_gfdlmprad_noahmp                                                                                                           | standard    |                | fv3         |
 RUN     | fv3_thompson                                                                                                                   | standard    |                | fv3         |
@@ -25,9 +24,6 @@ RUN     | fv3_wrtGauss_netcdf_esmf                                              
 RUN     | fv3_wrtGauss_netcdf                                                                                                            | standard    |                | fv3         |
 RUN     | fv3_wrtGauss_nemsio                                                                                                            | standard    |                | fv3         |
 RUN     | fv3_wrtGauss_nemsio_c192                                                                                                       | standard    |                | fv3         |
-RUN     | fv3_wrtGauss_nemsio_c768                                                                                                       | standard    | hera.intel     | fv3         |
-RUN     | fv3_wrtGauss_nemsio_c768                                                                                                       | standard    | cheyenne.intel | fv3         |
-RUN     | fv3_wrtGauss_nemsio_c768                                                                                                       | standard    | wcoss_cray     | fv3         |
 RUN     | fv3_stochy                                                                                                                     | standard    |                | fv3         |
 RUN     | fv3_iau                                                                                                                        | standard    |                | fv3         |
 RUN     | fv3_csawmgshoc                                                                                                                 | standard    |                | fv3         |
@@ -36,6 +32,15 @@ RUN     | fv3_rasmgshoc                                                         
 RUN     | fv3_csawmg3shoc127                                                                                                             | standard    |                | fv3         |
 RUN     | fv3_satmedmf                                                                                                                   | standard    |                | fv3         |
 RUN     | fv3_lheatstrg                                                                                                                  | standard    |                | fv3         |
+
+COMPILE | WW3=Y                                                                                                                          | standard    | wcoss_cray     | fv3         |
+COMPILE | WW3=Y                                                                                                                          | standard    | wcoss_dell_p3  | fv3         |
+COMPILE | WW3=Y                                                                                                                          | standard    | hera.intel     | fv3         |
+COMPILE | WW3=Y                                                                                                                          | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_gfdlmprad                                                                                                                  | standard    |                | fv3         |
+RUN     | fv3_wrtGauss_nemsio_c768                                                                                                       | standard    | hera.intel     | fv3         |
+RUN     | fv3_wrtGauss_nemsio_c768                                                                                                       | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_wrtGauss_nemsio_c768                                                                                                       | standard    | wcoss_cray     | fv3         |
 
 # Run one test using the NEMSAppBuilder, to ensure we don't break it:
 APPBUILD| standaloneFV3                                                                                                                  | standard    | wcoss_cray     |             |
@@ -101,9 +106,6 @@ RUN     | fv3_wrtGauss_netcdf_esmf                                              
 RUN     | fv3_wrtGauss_netcdf                                                                                                            | standard    |                | fv3         |
 RUN     | fv3_wrtGauss_nemsio                                                                                                            | standard    |                | fv3         |
 RUN     | fv3_wrtGauss_nemsio_c192                                                                                                       | standard    |                | fv3         |
-RUN     | fv3_wrtGauss_nemsio_c768                                                                                                       | standard    | hera.intel     | fv3         |
-RUN     | fv3_wrtGauss_nemsio_c768                                                                                                       | standard    | cheyenne.intel | fv3         |
-RUN     | fv3_wrtGauss_nemsio_c768                                                                                                       | standard    | wcoss_cray     | fv3         |
 RUN     | fv3_stochy                                                                                                                     | standard    |                | fv3         |
 RUN     | fv3_iau                                                                                                                        | standard    |                | fv3         |
 RUN     | fv3_gfdlmp                                                                                                                     | standard    |                | fv3         |
@@ -113,6 +115,13 @@ RUN     | fv3_csawmgshoc                                                        
 RUN     | fv3_csawmg3shoc127                                                                                                             | standard    |                | fv3         |
 RUN     | fv3_csawmg                                                                                                                     | standard    |                | fv3         |
 RUN     | fv3_satmedmf                                                                                                                   | standard    |                | fv3         |
+
+COMPILE | REPRO=Y WW3=Y                                                                                                                  | standard    | hera.intel     | fv3         |
+COMPILE | REPRO=Y WW3=Y                                                                                                                  | standard    | cheyenne.intel | fv3         |
+COMPILE | REPRO=Y WW3=Y                                                                                                                  | standard    | wcoss_cray     | fv3         |
+RUN     | fv3_wrtGauss_nemsio_c768                                                                                                       | standard    | hera.intel     | fv3         |
+RUN     | fv3_wrtGauss_nemsio_c768                                                                                                       | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_wrtGauss_nemsio_c768                                                                                                       | standard    | wcoss_cray     | fv3         |
 
 # Run one test using the NEMSAppBuilder, to ensure we don't break it:
 APPBUILD| standaloneFV3_repro                                                                                                            | standard    | wcoss_cray     |             |
@@ -274,11 +283,15 @@ RUN     | fv3_ccpp_wrtGauss_netcdf_esmf                                         
 RUN     | fv3_ccpp_wrtGauss_netcdf                                                                                                       | standard    |                | fv3         |
 RUN     | fv3_ccpp_wrtGauss_nemsio                                                                                                       | standard    |                | fv3         |
 RUN     | fv3_ccpp_wrtGauss_nemsio_c192                                                                                                  | standard    |                | fv3         |
+RUN     | fv3_ccpp_stochy                                                                                                                | standard    |                | fv3         |
+RUN     | fv3_ccpp_iau                                                                                                                   | standard    |                | fv3         |
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017 WW3=Y                                                                                      | standard    | hera.intel     | fv3         |
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017 WW3=Y                                                                                      | standard    | cheyenne.intel | fv3         |
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017 WW3=Y                                                                                      | standard    | wcoss_cray     | fv3         |
 RUN     | fv3_ccpp_wrtGauss_nemsio_c768                                                                                                  | standard    | hera.intel     | fv3         |
 RUN     | fv3_ccpp_wrtGauss_nemsio_c768                                                                                                  | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_wrtGauss_nemsio_c768                                                                                                  | standard    | wcoss_cray     | fv3         |
-RUN     | fv3_ccpp_stochy                                                                                                                | standard    |                | fv3         |
-RUN     | fv3_ccpp_iau                                                                                                                   | standard    |                | fv3         |
 
 # Run one test using the NEMSAppBuilder, to ensure we don't break it:
 APPBUILD| CCPP                                                                                                                           | standard    | wcoss_cray     |             |

--- a/tests/rt_fv3.sh
+++ b/tests/rt_fv3.sh
@@ -32,6 +32,8 @@ atparse < ${PATHTR}/parm/${INPUT_NML:-input.nml.IN} > input.nml
 
 atparse < ${PATHTR}/parm/${MODEL_CONFIGURE:-model_configure.IN} > model_configure
 
+atparse < ${PATHTR}/parm/${NEMS_CONFIGURE:-nems.configure} > nems.configure
+
 if [[ "Q${INPUT_NEST02_NML:-}" != Q ]] ; then
     atparse < ${PATHTR}/parm/${INPUT_NEST02_NML} > input_nest02.nml
 fi
@@ -69,6 +71,8 @@ elif [[ $SCHEDULER = 'lsf' ]]; then
   fi
   atparse < $PATHRT/fv3_conf/fv3_bsub.IN > job_card
 fi
+
+atparse < ${PATHTR}/parm/${NEMS_CONFIGURE:-nems.configure} > nems.configure
 
 ################################################################################
 # Submit test

--- a/tests/tests/fv3_gfdlmprad
+++ b/tests/tests/fv3_gfdlmprad
@@ -53,6 +53,8 @@ export LIST_FILES="atmos_4xdaily.tile1.nc \
 
 
 export_fv3
+
+export TASKS=192
 export NODES=$(expr $TASKS / $TPN + 1)
 
 DT_ATMOS="1200"
@@ -64,6 +66,14 @@ export OUTPUT_FILE="'nemsio'"
 export WRITE_NEMSIOFLIP=.true.
 export WRITE_FSYNCFLAG=.true.
 
+export CPL=.true.
+export CPLWAV=.T.
+export atm_model='fv3'
+export atm_petlist_bounds="0 149"
+export wav_model='ww3'
+export wav_petlist_bounds="150 191"
+export coupling_interval_sec=3600.0  #coupling time step, want it to be multiple of 1800 and FV3 time step
+export NEMS_CONFIGURE="nems.configure.blocked_atm_wav.IN"
 
 export INPUT_NML=gfdlmp.nml.IN
 export FV3_RUN=gfdlmp_run.IN

--- a/tests/tests/fv3_wrtGauss_nemsio_c768
+++ b/tests/tests/fv3_wrtGauss_nemsio_c768
@@ -51,12 +51,17 @@ export LIST_FILES="atmos_4xdaily.tile1.nc \
 
 
 export_fv3
-export TASKS=1728
+
+export TASKS=1752
 if [[ $MACHINE_ID = cheyenne.* ]]; then
   export TPN=36
+elif [[ $MACHINE_ID = hera.* ]]; then
+  export TPN=30
 else
   export TPN=12
 fi
+export NODES=$(expr $TASKS / $TPN + 1)
+
 export INPES=16
 export JNPES=16
 export NPX=769
@@ -83,7 +88,14 @@ export FNVETC="'global_vegtype.igbp.t1534.3072.1536.rg.grb',"
 export FNSOTC="'global_soiltype.statsgo.t1534.3072.1536.rg.grb',"
 export FNSMCC="'global_soilmgldas.t1534.3072.1536.grb',"
 export FNABSC="'global_mxsnoalb.uariz.t1534.3072.1536.rg.grb',"
-export NODES=$(expr $TASKS / $TPN + 1)
 
-#
+export CPL=.true.
+export CPLWAV=.T.
+export atm_model='fv3'
+export atm_petlist_bounds="0 1727"
+export wav_model='ww3'
+export wav_petlist_bounds="1728 1751"
+export coupling_interval_sec=1800.0  #coupling time step, want it to be multiple of 1800 and FV3 time step
+export NEMS_CONFIGURE="nems.configure.blocked_atm_wav.IN"
+
 RUN_SCRIPT=rt_fv3.sh


### PR DESCRIPTION
* Updated WW3 which includes updates for:
    -- hera support
    -- Adding capability for interpolation from regular grid to curvilinear grids
    -- Switch WRST for storing wind in the restart and using it for the first time step in the NUOPC cap.
* NEMSCompsetRun tests with WW3 run on hera
* updates so that wave coupling is tested in the rt.sh tests
* WW3 output added to baselines for checking results
