### PR TITLE
CHSP: additional regression tests, reduced timestep, ecflow for cheyenne

### DIFF
--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -29,6 +29,7 @@ RUN     | fv3_csawmg                                                            
 RUN     | fv3_rasmgshoc                                                                                                                  | standard    |                | fv3         |
 RUN     | fv3_csawmg3shoc127                                                                                                             | standard    |                | fv3         |
 RUN     | fv3_satmedmf                                                                                                                   | standard    |                | fv3         |
+RUN     | fv3_satmedmfq                                                                                                                  | standard    |                | fv3         |
 RUN     | fv3_lheatstrg                                                                                                                  | standard    |                | fv3         |
 RUN     | fv3_gfsv16_csawmg                                                                                                              | standard    |                | fv3         |
 RUN     | fv3_gocart_clm                                                                                                                 | standard    |                | fv3         |
@@ -110,6 +111,8 @@ RUN     | fv3_csawmgshoc                                                        
 RUN     | fv3_csawmg3shoc127                                                                                                             | standard    |                | fv3         |
 RUN     | fv3_csawmg                                                                                                                     | standard    |                | fv3         |
 RUN     | fv3_satmedmf                                                                                                                   | standard    |                | fv3         |
+RUN     | fv3_satmedmfq                                                                                                                  | standard    |                | fv3         |
+RUN     | fv3_lheatstrg                                                                                                                  | standard    |                | fv3         |
 RUN     | fv3_gfsv16_csawmg                                                                                                              | standard    |                | fv3         |
 RUN     | fv3_gocart_clm                                                                                                                 | standard    |                | fv3         |
 RUN     | fv3_gfsv16_csawmgt                                                                                                             | standard    |                | fv3         |
@@ -178,6 +181,7 @@ RUN     | fv3_ccpp_wrtGauss_nemsio                                              
 RUN     | fv3_ccpp_wrtGauss_nemsio_c192                                                                                                  | standard    |                |             |
 RUN     | fv3_ccpp_stochy                                                                                                                | standard    |                | fv3         |
 RUN     | fv3_ccpp_iau                                                                                                                   | standard    |                |             |
+RUN     | fv3_ccpp_lheatstrg                                                                                                             | standard    |                |             |
 
 COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y                                                          | standard    | wcoss_cray     |             |
 COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y                                                          | standard    | wcoss_dell_p3  |             |
@@ -234,16 +238,17 @@ RUN     | fv3_ccpp_gfdlmp                                                       
 RUN     | fv3_ccpp_gfdlmprad_gwd                                                                                                         | standard    |                |             |
 RUN     | fv3_ccpp_gfdlmprad_noahmp                                                                                                      | standard    |                |             |
 
-COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf                               | standard    | wcoss_cray     |             |
-COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf                               | standard    | wcoss_dell_p3  |             |
-COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf                               | standard    | hera.intel     |             |
-COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf                               | standard    | gaea.intel     |             |
-COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf                               | standard    | jet.intel      |             |
+COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq        | standard    | wcoss_cray     |             |
+COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq        | standard    | wcoss_dell_p3  |             |
+COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq        | standard    | hera.intel     |             |
+COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq        | standard    | gaea.intel     |             |
+COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq        | standard    | jet.intel      |             |
 
 #RUN     | fv3_ccpp_csawmgshoc                                                                                                            | standard    |                |             |
 #RUN     | fv3_ccpp_csawmg3shoc127                                                                                                        | standard    |                |             |
 RUN     | fv3_ccpp_csawmg                                                                                                                | standard    |                |             |
 RUN     | fv3_ccpp_satmedmf                                                                                                              | standard    |                |             |
+RUN     | fv3_ccpp_satmedmfq                                                                                                             | standard    |                |             |
 
 COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0 32BIT=Y                                               | standard    | wcoss_cray     | fv3         |
 COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0 32BIT=Y                                               | standard    | wcoss_dell_p3  | fv3         |
@@ -284,6 +289,7 @@ RUN     | fv3_ccpp_iau                                                          
 # temporarily disabled for gaea.intel (intel18): gives different results when creating baseline and verifying against it
 #RUN     | fv3_ccpp_iau                                                                                                                   | standard    | gaea.intel     | fv3         |
 RUN     | fv3_ccpp_iau                                                                                                                   | standard    | jet.intel      | fv3         |
+RUN     | fv3_ccpp_lheatstrg                                                                                                             | standard    |                | fv3         |
 
 COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y                                                                  | standard    | wcoss_cray     | fv3         |
 COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y                                                                  | standard    | wcoss_dell_p3  | fv3         |
@@ -349,16 +355,17 @@ RUN     | fv3_ccpp_gfdlmp                                                       
 RUN     | fv3_ccpp_gfdlmprad_gwd                                                                                                         | standard    |                | fv3         |
 RUN     | fv3_ccpp_gfdlmprad_noahmp                                                                                                      | standard    |                | fv3         |
 
-COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf                                       | standard    | wcoss_cray     | fv3         |
-COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf                                       | standard    | wcoss_dell_p3  | fv3         |
-COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf                                       | standard    | hera.intel     | fv3         |
-COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf                                       | standard    | gaea.intel     | fv3         |
-COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf                                       | standard    | jet.intel      | fv3         |
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq                | standard    | wcoss_cray     | fv3         |
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq                | standard    | wcoss_dell_p3  | fv3         |
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq                | standard    | hera.intel     | fv3         |
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq                | standard    | gaea.intel     | fv3         |
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf,FV3_GFS_2017_satmedmfq                | standard    | jet.intel      | fv3         |
 
 #RUN     | fv3_ccpp_csawmgshoc                                                                                                            | standard    |                | fv3         |
 #RUN     | fv3_ccpp_csawmg3shoc127                                                                                                        | standard    |                | fv3         |
 RUN     | fv3_ccpp_csawmg                                                                                                                | standard    |                | fv3         |
 RUN     | fv3_ccpp_satmedmf                                                                                                              | standard    |                | fv3         |
+RUN     | fv3_ccpp_satmedmfq                                                                                                             | standard    |                | fv3         |
 
 COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y                                  | standard    | wcoss_cray     | fv3         |
 COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y                                  | standard    | wcoss_dell_p3  | fv3         |

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -269,8 +269,11 @@ elif [[ $MACHINE_ID = cheyenne.* ]]; then
   # Re-instantiate COMPILER in case it gets deleted by module purge
   COMPILER=${NEMS_COMPILER:-intel}
 
-  export PYTHONPATH=
-  ECFLOW_START=
+  module load python/2.7.16
+  export PATH=/glade/p/ral/jntp/tools/ecFlow-5.3.1/bin:$PATH
+  export PYTHONPATH=/glade/p/ral/jntp/tools/ecFlow-5.3.1/lib/python2.7/site-packages
+  ECFLOW_START=/glade/p/ral/jntp/tools/ecFlow-5.3.1/bin/ecflow_start.sh
+  ECF_PORT=$(( $(id -u) + 1500 ))
   QUEUE=premium
   PARTITION=
   dprefix=/glade/scratch
@@ -512,6 +515,8 @@ EOF
     QUEUE=batch
   elif [[ $MACHINE_ID = jet.* ]]; then
     QUEUE=batch
+  elif [[ $MACHINE_ID = cheyenne.* ]]; then
+    QUEUE=premium
   else
     die "ecFlow is not supported on this machine $MACHINE_ID"
   fi

--- a/tests/tests/fv3_ccpp_satmedmf
+++ b/tests/tests/fv3_ccpp_satmedmf
@@ -55,6 +55,8 @@ export LIST_FILES="atmos_4xdaily.tile1.nc \
 export_fv3
 export NODES=$(expr $TASKS / $TPN + 1)
 
+export DT_ATMOS="1200"
+
 export SATMEDMF=.T.
 export HYBEDMF=.F.
 export OUTPUT_GRID="'gaussian_grid'"

--- a/tests/tests/fv3_ccpp_satmedmfq
+++ b/tests/tests/fv3_ccpp_satmedmfq
@@ -55,6 +55,8 @@ export LIST_FILES="atmos_4xdaily.tile1.nc \
 export_fv3
 export NODES=$(expr $TASKS / $TPN + 1)
 
+export DT_ATMOS="1200"
+
 export SATMEDMF=.T.
 export ISATMEDMF=1
 export HYBEDMF=.F.

--- a/tests/tests/fv3_satmedmf
+++ b/tests/tests/fv3_satmedmf
@@ -55,6 +55,8 @@ export LIST_FILES="atmos_4xdaily.tile1.nc \
 export_fv3
 export NODES=$(expr $TASKS / $TPN + 1)
 
+export DT_ATMOS="1200"
+
 export SATMEDMF=.T.
 export HYBEDMF=.F.
 export OUTPUT_GRID="'gaussian_grid'"

--- a/tests/tests/fv3_satmedmfq
+++ b/tests/tests/fv3_satmedmfq
@@ -55,6 +55,8 @@ export LIST_FILES="atmos_4xdaily.tile1.nc \
 export_fv3
 export NODES=$(expr $TASKS / $TPN + 1)
 
+export DT_ATMOS="1200"
+
 export SATMEDMF=.T.
 export ISATMEDMF=1
 export HYBEDMF=.F.


### PR DESCRIPTION
- add regression tests for lheatstrg to IPD REPRO, CCPP REPRO, CCPP PROD
- add regression tests for satmedmfvdifq for IPD PROD, IPD REPRO, CCPP REPRO, CCPP PROD
- reduce model time step from 1800s to 1200s for all satmedmf and satmedmfq regression tests
- add ecflow config for cheyenne