### PR TITLE
Change skip-ci to run-ci. Remove pull_request_review trigger

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,8 +3,7 @@ name: Pull request tests
 on:
   push:
     branches: ['develop']
-  pull_request_review:
-    types: [submitted]
+  pull_request:
     branches: ['develop']
 
 jobs:
@@ -45,7 +44,6 @@ jobs:
   build:
     name: Build (${{ matrix.bld_set }})
     needs: setup
-    if: github.event_name == 'push' || (github.event.review.state == 'approved' && toJson(github.event.pull_request.requested_reviewers) == '[]')
     runs-on: ubuntu-20.04
 
     strategy:

--- a/.github/workflows/manage_workflows.yml
+++ b/.github/workflows/manage_workflows.yml
@@ -15,22 +15,23 @@ jobs:
       - name: Checkout codes
         uses: actions/checkout@v2
 
-      - name: Check if skip-ci is requested
+      - name: Check if run-ci is requested
         run: |
           sleep 40
           cd ${GITHUB_WORKSPACE}/tests/ci
           repo="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs"
           tr_id=$(cat ${GITHUB_EVENT_PATH} | ./json_helper.py get_trigger_id)
           tr_br=$(cat ${GITHUB_EVENT_PATH} | ./json_helper.py get_trigger_br)
-          check=$(cat ${GITHUB_EVENT_PATH} | ./json_helper.py check_skip)
+          check=$(cat ${GITHUB_EVENT_PATH} | ./json_helper.py check_run)
           echo "TRIGGER_ID=${tr_id}" >> $GITHUB_ENV
           echo "TRIGGER_BR=${tr_br}" >> $GITHUB_ENV
-          echo "skip-ci: ${check}"
-          if [[ $check == yes ]]; then
-            echo "skip-ci is requested"
+          echo "run-ci: ${check}"
+          if [[ $check == no ]]; then
+            echo "run-ci is not requested"
             echo "CURR_JOB=cancelled" >> $GITHUB_ENV
             curl -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" ${repo}/$tr_id/cancel
           else
+            echo "run-ci is requested"
             echo "CURR_JOB=running" >> $GITHUB_ENV
           fi
 

--- a/tests/ci/json_helper.py
+++ b/tests/ci/json_helper.py
@@ -6,9 +6,9 @@ import re
 import sys
 import json
 
-def check_skip(data):
+def check_run(data):
   msg = data["head_commit"]["message"]
-  if re.search("skip-ci", msg):
+  if re.search("run-ci", msg):
     return "yes"
   else:
     return "no"
@@ -26,9 +26,9 @@ def cancel_workflow(data):
 
 def main():
 
-  if sys.argv[1]=="check_skip":
+  if sys.argv[1]=="check_run":
     data = json.load(sys.stdin)["workflow_run"]
-    ans = check_skip(data)
+    ans = check_run(data)
     print(ans)
   elif sys.argv[1]=="get_trigger_id":
     print(json.load(sys.stdin)["workflow_run"]["id"])


### PR DESCRIPTION
## Description

Changes in how CI is triggered/run:
- Currently CI runs once when all reviewers approve the code changes.
- After this PR commit, CI will run only when "run-ci" is specified in the commit message

## Testing

This only affect CI related files in .github/workflows and tests/ci directories. No testing is required.

## Dependencies

No dependencies.