### PR TITLE
Fix for new ECFlow requirements on hera

### DIFF
--- a/tests/detect_machine.sh
+++ b/tests/detect_machine.sh
@@ -59,6 +59,7 @@ case $(hostname -f) in
   hfe10)                   MACHINE_ID=hera ;; ### hera10
   hfe11)                   MACHINE_ID=hera ;; ### hera11
   hfe12)                   MACHINE_ID=hera ;; ### hera12
+  hecflow01)               MACHINE_ID=hera ;; ### heraecflow01
 
   fe1)                     MACHINE_ID=jet ;; ### jet01
   fe2)                     MACHINE_ID=jet ;; ### jet02

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -235,8 +235,13 @@ elif [[ $MACHINE_ID = hera.* ]]; then
   PYTHONHOME=/scratch1/NCEPDEV/nems/emc.nemspara/soft/miniconda3_new_20210629
   export PATH=$PYTHONHOME/bin:$PATH
   export PYTHONPATH=$PYTHONHOME/lib/python3.7/site-packages
-  ECFLOW_START=$PYTHONHOME/bin/ecflow_start.sh
-  ECF_PORT=$(( $(id -u) + 1500 ))
+
+  if [[ ! $HOSTNAME = hecflow* ]]; then
+    echo "ERROR: On Hera we must be logged into 'hecflow' login nodes"
+    exit 1
+  fi
+  module load ecflow
+  ECFLOW_START=ecflow_start.sh
 
   QUEUE=debug
   COMPILE_QUEUE=batch

--- a/tests/rt_utils.sh
+++ b/tests/rt_utils.sh
@@ -538,7 +538,7 @@ ecflow_run() {
   not_running=$?
   if [[ $not_running -eq 1 ]]; then
     echo "ecflow_server is NOT running on ${ECF_HOST}:${ECF_PORT}"
-    sh ${ECFLOW_START} -p ${ECF_PORT}
+    ${ECFLOW_START} -p ${ECF_PORT}
   else
     echo "ecflow_server is already running on ${ECF_HOST}:${ECF_PORT}"
   fi


### PR DESCRIPTION
Fixes for Hera ecflow. Must be run on hecflow01 login node. If run manually must `module load ecflow` and `ecflow_start.sh`

Closes #707 & #706 in ufs-community/ufs-weather-model