### PR TITLE
Intel2022: update Cheyenne hpc-stack locations

### DIFF
--- a/modulefiles/ufs_cheyenne.gnu
+++ b/modulefiles/ufs_cheyenne.gnu
@@ -16,7 +16,7 @@ module load mpt/2.22
 module load ncarcompilers/0.5.0
 module unload netcdf
 
-module use /glade/work/epicufsrt/GMTB/tools/hpc-stack-v1.2.0_6eb6/modulefiles/stack
+module use /glade/work/epicufsrt/GMTB/tools/gnu/10.1.0/hpc-stack-v1.2.0/modulefiles/stack
 module load hpc/1.2.0
 module load hpc-gnu/10.1.0
 module load hpc-mpt/2.22

--- a/modulefiles/ufs_cheyenne.gnu_debug
+++ b/modulefiles/ufs_cheyenne.gnu_debug
@@ -16,7 +16,7 @@ module load mpt/2.22
 module load ncarcompilers/0.5.0
 module unload netcdf
 
-module use /glade/work/epicufsrt/GMTB/tools/hpc-stack-v1.2.0_6eb6/modulefiles/stack
+module use /glade/work/epicufsrt/GMTB/tools/gnu/10.1.0/hpc-stack-v1.2.0/modulefiles/stack
 module load hpc/1.2.0
 module load hpc-gnu/10.1.0
 module load hpc-mpt/2.22

--- a/modulefiles/ufs_cheyenne.intel
+++ b/modulefiles/ufs_cheyenne.intel
@@ -11,16 +11,16 @@ module load python/3.7.9
 
 # load programming environment
 module load ncarenv/1.3
-module load intel/2021.2
-module load mpt/2.22
+module load intel/2022.1
+module load mpt/2.25
 module load ncarcompilers/0.5.0
 module unload netcdf
 
-module use /glade/work/epicufsrt/GMTB/tools/hpc-stack-v1.2.0_6eb6/modulefiles/stack
+module use /glade/work/epicufsrt/GMTB/tools/intel/2022.1/hpc-stack-v1.2.0_6eb6/modulefiles/stack
 
 module load hpc/1.2.0
 module load hpc-intel/2021.2
-module load hpc-mpt/2.22
+module load hpc-mpt/2.25
 
 module load ufs_common
 

--- a/modulefiles/ufs_cheyenne.intel_debug
+++ b/modulefiles/ufs_cheyenne.intel_debug
@@ -11,15 +11,16 @@ module load python/3.7.9
 
 # load programming environment
 module load ncarenv/1.3
-module load intel/2021.2
-module load mpt/2.22
+module load intel/2022.1
+module load mpt/2.25
 module load ncarcompilers/0.5.0
 module unload netcdf
 
-module use /glade/work/epicufsrt/GMTB/tools/hpc-stack-v1.2.0_6eb6/modulefiles/stack
+module use /glade/work/epicufsrt/GMTB/tools/intel/2022.1/hpc-stack-v1.2.0_6eb6/modulefiles/stack
+
 module load hpc/1.2.0
-module load hpc-intel/2021.2
-module load hpc-mpt/2.22
+module load hpc-intel/2022.1
+module load hpc-mpt/2.25
 
 module load ufs_common_debug
 


### PR DESCRIPTION
## Description
Upgrade of Cheyenne intel2022.1 and  g2 (3.4.5), Jasper (2.0.25), PIO (2.5.3), libpng (1.6.37)


## Testing

1. Tested ok on Cheyenne: new location of gnu10.1.0/hpc-stack
2. intel2022.1 upgrade on Cheyenne: change result only by compiler upgrade but not from library updates, (g2 (3.4.5), Jasper (2.0.25), PIO (2.5.3), libpng (1.6.37)) 

